### PR TITLE
Use pibooth logger instead of custom config value

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,17 @@ Here below the new configuration options available in the `pibooth`_ configurati
 
     [DROPBOX]
 
-    # Album where pictures are uploaded
+    # Dropbox folder where pictures are uploaded. Subfolders can be separated by /
     album_name = Pibooth
 
-    # Credentials file downloaded from Google API
-    client_id_file =
+    # Refresh-Token for the dropbox api
+    token =
+
+    # Dropbox Application Key
+    app_key =
+
+    # Dropbox Application Password
+    app_secret =
 
 .. note:: Edit the configuration by running the command ``pibooth --config``.
 
@@ -65,10 +71,10 @@ https://stackoverflow.com/questions/70641660/how-do-you-get-and-use-a-refresh-to
    :target: https://www.python.org/downloads
    :alt: Python 3.6+
 
-.. |PypiPackage| image:: https://badge.fury.io/py/pibooth-google-photo.svg
-   :target: https://pypi.org/project/pibooth-google-photo
+.. |PypiPackage| image:: https://badge.fury.io/py/pibooth-dropbox.svg
+   :target: https://pypi.org/project/pibooth-dropbox
    :alt: PyPi package
 
-.. |Downloads| image:: https://img.shields.io/pypi/dm/pibooth-google-photo?color=purple
-   :target: https://pypi.org/project/pibooth-google-photo
+.. |Downloads| image:: https://img.shields.io/pypi/dm/pibooth-dropbox?color=purple
+   :target: https://pypi.org/project/pibooth-dropbox
    :alt: PyPi downloads

--- a/pibooth_dropbox.py
+++ b/pibooth_dropbox.py
@@ -5,37 +5,30 @@
 import contextlib
 import datetime
 import os.path
-import sys
 import time
 import dropbox
 
 import pibooth
 from pibooth.utils import LOGGER
 
-if sys.version.startswith('2'):
-    input = raw_input  # noqa: E501,F821; pylint: disable=redefined-builtin,undefined-variable,useless-suppression
-
 __version__ = "0.0.1"
 
+
 SECTION = 'DROPBOX'
-ZEROONE = ['0', '1']
 
 
 @pibooth.hookimpl
 def pibooth_configure(cfg):
     """Declare the new configuration options"""
-    cfg.add_option(SECTION, 'db_album_name', "Pibooth",
+    cfg.add_option(SECTION, 'album_name', "Pibooth",
                    "Dropbox folder where pictures are uploaded. Subfolders can be separated by /",
                    "Folder name", "Pibooth")
-    cfg.add_option(SECTION, 'db_token', '',
+    cfg.add_option(SECTION, 'token', '',
                    "Refresh-Token for the dropbox api")
-    cfg.add_option(SECTION, 'db_app_key', '',
+    cfg.add_option(SECTION, 'app_key', '',
                    "Dropbox Application Key")
-    cfg.add_option(SECTION, 'db_app_secret', '',
+    cfg.add_option(SECTION, 'app_secret', '',
                    "Dropbox Application Password")
-    cfg.add_option(SECTION, 'db_debug', '0',
-                   "Dropbox Debug Mode {}".format(', '.join(ZEROONE)),
-                   "Debug Mode (0 or 1)", ZEROONE)
 
 
 @pibooth.hookimpl
@@ -43,15 +36,13 @@ def pibooth_startup(app, cfg):
     """Create the Dropbox upload instance."""
 
     get_config_options(app, cfg)
-
-    if app.dropbox_debug == 1 or app.dropbox_debug == "1":
-        LOGGER.info("Starting Dropbox init")
+    LOGGER.debug("Starting Dropbox init")
 
     app.previous_picture_url = None
     client_id_token = app.dropbox_token
 
     if not client_id_token:
-        LOGGER.debug("No token defined in [DROPBOX][db_token], upload deactivated")
+        LOGGER.debug("No token defined in [DROPBOX][token], upload deactivated")
         app.dbx = None
     else:
         try:
@@ -65,42 +56,37 @@ def pibooth_startup(app, cfg):
             LOGGER.debug('Dropbox Api initialization error, upload deactivated!')
             app.dbx = None
 
-    if app.dropbox_debug == 1 or app.dropbox_debug == "1":
-        LOGGER.info("Dropbox init done")
+    LOGGER.debug("Dropbox init done")
 
 
 @pibooth.hookimpl
 def state_processing_exit(app, cfg):
     """Upload picture to dropbox folder"""
-    if hasattr(app, 'dropbox') and app.dbx != None:
+    if hasattr(app, 'dropbox') and app.dbx is not None:
 
         get_config_options(app, cfg)
 
         result = app.dropbox.upload(app.dbx, app.previous_picture_file, app.dropbox_album_name,
-                                    os.path.basename(app.previous_picture_file), app.dropbox_debug)
+                                    os.path.basename(app.previous_picture_file))
 
-        if result != None:
-            app.previous_picture_url = app.dropbox.get_temp_link(app.dbx, result.path_lower, app.dropbox_debug)
+        if result is not None:
+            app.previous_picture_url = app.dropbox.get_temp_link(app.dbx, result.path_lower)
         else:
             app.previous_picture_url = None
 
 
 class dropboxApi(object):
 
-    def upload(self, dbx, fullname, folder, name, debugmode, overwrite=False):
+    def upload(self, dbx, fullname, folder, name, overwrite=False):
         """Upload a file.
         Return the request response, or None in case of error.
         """
-
-        if debugmode == 1 or debugmode == "1":
-            LOGGER.info('fullname -> ' + fullname)
-            LOGGER.info('folder -> ' + folder)
-            LOGGER.info('name -> ' + name)
+        LOGGER.debug('fullname -> %s', fullname)
+        LOGGER.debug('folder -> %s', folder)
+        LOGGER.debug('name -> %s', name)
 
         path = '/%s/%s' % (folder, name)
-
-        if debugmode == 1 or debugmode == "1":
-            LOGGER.info('path -> ' + path)
+        LOGGER.debug('path -> %s', path)
 
         while '//' in path:
             path = path.replace('//', '/')
@@ -108,48 +94,42 @@ class dropboxApi(object):
                 if overwrite
                 else dropbox.files.WriteMode.add)
         mtime = os.path.getmtime(fullname)
-        with open(fullname, 'rb') as f:
-            data = f.read()
+
+        with open(fullname, 'rb') as fd:
+            data = fd.read()
+
         with stopwatch('upload %d bytes' % len(data)):
             try:
                 res = dbx.files_upload(
                     data, path, mode,
                     client_modified=datetime.datetime(*time.gmtime(mtime)[:6]),
                     mute=True)
-            except dropbox.exceptions.ApiError as err:
-                Logger.info('*** Dropbox API error', err)
+            except dropbox.exceptions.ApiError:
+                LOGGER.error('*** Dropbox API error', exc_info=True)
                 return None
-        if debugmode == 1 or debugmode == "1":
-            LOGGER.info('uploaded as {}'.format(res.name.encode('utf8')))
 
+        LOGGER.debug('Pploaded as %s', res.name.encode('utf8'))
         return res
 
-    def get_temp_link(self, dbx, path, debugmode):
+    def get_temp_link(self, dbx, path):
         """ Get the temporary link for the picture. Link is valid 4 hours only. """
-
         res = dbx.files_get_temporary_link(path)
-
-        if debugmode == 1 or debugmode == "1":
-            LOGGER.info('dropbox temp picture path -> ' + res.link)
-
+        LOGGER.debug('dropbox temp picture path -> %s', res.link)
         return res.link
 
 
 def get_config_options(app, cfg):
     """ Read options at each hook. Options can change at runtime """
 
-    app.dropbox_album_name = cfg.get(SECTION, 'db_album_name')
-    app.dropbox_token = cfg.get(SECTION, 'db_token')
-    app.dropbox_app_key = cfg.get(SECTION, 'db_app_key')
-    app.dropbox_app_secret = cfg.get(SECTION, 'db_app_secret')
-    app.dropbox_debug = cfg.get(SECTION, 'db_debug')
+    app.dropbox_album_name = cfg.get(SECTION, 'album_name')
+    app.dropbox_token = cfg.get(SECTION, 'token')
+    app.dropbox_app_key = cfg.get(SECTION, 'app_key')
+    app.dropbox_app_secret = cfg.get(SECTION, 'app_secret')
 
-    if app.dropbox_debug == 1 or app.dropbox_debug == "1":
-        LOGGER.info("dropbox_album_name -> " + app.dropbox_album_name)
-        LOGGER.info("dropbox_token -> " + app.dropbox_token)
-        LOGGER.info("dropbox_app_key -> " + app.dropbox_app_key)
-        LOGGER.info("dropbox_app_secret -> " + app.dropbox_app_secret)
-        LOGGER.info("dropbox_debug -> " + app.dropbox_debug)
+    LOGGER.debug("Dropbox album_name -> %s", app.dropbox_album_name)
+    LOGGER.debug("Dropbox token -> %s", app.dropbox_token)
+    LOGGER.debug("Dropbox app_key -> %s", app.dropbox_app_key)
+    LOGGER.debug("Dropbox app_secret -> %s", app.dropbox_app_secret)
 
 
 @contextlib.contextmanager
@@ -160,4 +140,4 @@ def stopwatch(message):
         yield
     finally:
         t1 = time.time()
-        LOGGER.info('Total elapsed time for %s: %.3f' % (message, t1 - t0))
+        LOGGER.debug('Total elapsed time for %s: %.3f', message, t1 - t0)


### PR DESCRIPTION
- Rework logging messages to avoid custom config key in configuration file
- Rename config key prefix  `db_` because already in a section dedicated to Dropbox
- Replace custom function `stopwatch` by `timeit`
